### PR TITLE
Different redirect urls for different vhosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Role Variables
 | apache_server_name   | server domain name |
 | apache_server_admin  | server admin email  |
 | apache_server_alias  | list of alternate server names  |
-| apache_redirect_url  | url for Redirect directive  |
+| apache_redirect_url  | default url to define a redirect in vhosts  |
+| apache_vhost80_redirect_url  | url to define a redirect in virtualhost *:80  |
+| apache_vhost443_redirect_url  | url to define a redirect in virtualhost *:443  |
 | apache_ssl_certificate_file  | ssl cert file location |
 | apache_ssl_certificate_key  | ssl key file location   |
 | apache_proxy_home_pass  | incoming requests  |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,8 @@ apache_server_name: "{{inventory_hostname}}"
 apache_server_admin: serveradmin@domain.com
 apache_server_alias: false
 apache_redirect_url: false
+apache_vhost80_redirect_url: false
+apache_vhost443_redirect_url: false
 apache_ssl_certificate_file: /etc/letsencrypt/live/{{inventory_hostname}}/cert.pem
 apache_ssl_certificate_key: /etc/letsencrypt/live/{{inventory_hostname}}/privkey.pem
 apache_ssl_certificate_fullchain: /etc/letsencrypt/live/{{inventory_hostname}}/fullchain.pem

--- a/templates/apache.conf.j2
+++ b/templates/apache.conf.j2
@@ -4,7 +4,9 @@
 {% if apache_server_alias %}
    ServerAlias {{apache_server_alias}}
 {% endif %}
-{% if apache_redirect_url %}
+{% if apache_vhost80_redirect_url %}
+   Redirect / {{apache_vhost80_redirect_url}}
+{% elif apache_redirect_url %}
    Redirect / {{apache_redirect_url}}
 {% endif %}
 </VirtualHost>
@@ -15,7 +17,9 @@
 {% if apache_server_alias %}
    ServerAlias {{apache_server_alias}}
 {% endif %}
-{% if apache_redirect_url %}
+{% if apache_vhost443_redirect_url %}
+   Redirect / {{apache_vhost443_redirect_url}}
+{% elif apache_redirect_url %}
    Redirect / {{apache_redirect_url}}
 {% endif %}
 


### PR DESCRIPTION
In general we need an http-https redirect and rarely we use a redirect on the virtualhost: 443. To solve this we now have two variables: `apache_vhost80_redirect_url` and `apache_vhost443_redirect_url`